### PR TITLE
Use contenthash for extract text plugin filename option

### DIFF
--- a/src/css.webpack.config.js
+++ b/src/css.webpack.config.js
@@ -74,7 +74,7 @@ export default ({
 
   const extractor = new ExtractTextPlugin({
     disable: !extract,
-    filename: '[name].[hash].css',
+    filename: '[name].[contenthash].css',
     ...extract,
   });
 


### PR DESCRIPTION
Using `contenthash` will base the hash on the contents of the file such that subsequent builds with no changes will result in the same hash.